### PR TITLE
ECOM-117 - Updates to SDK to fix misc. split merchant errors related …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "stack-pay/payments-sdk-php",
-    "version": "1.3.6",
+    "version": "1.3.5",
     "description": "Stack Pay API SDK for PHP",
     "keywords": ["stacksports", "stackpay", "payments", "api", "sdk"],
     "license": "MIT",

--- a/lib/Interfaces/PaymentPlanConfig.php
+++ b/lib/Interfaces/PaymentPlanConfig.php
@@ -6,9 +6,11 @@ interface PaymentPlanConfig
 {
     public function months();
     public function day();
+    public function gracePeriod();
 
     //-----------
 
     public function setMonths($months = null);
     public function setDay($day = null);
+    public function setGracePeriod($gracePeriod = null);
 }

--- a/lib/Structures/PaymentPlanConfig.php
+++ b/lib/Structures/PaymentPlanConfig.php
@@ -8,6 +8,7 @@ class PaymentPlanConfig implements Interfaces\PaymentPlanConfig
 {
     public $months;
     public $day;
+    public $gracePeriod;
 
     public function months()
     {
@@ -17,6 +18,11 @@ class PaymentPlanConfig implements Interfaces\PaymentPlanConfig
     public function day()
     {
         return $this->day;
+    }
+
+    public function gracePeriod()
+    {
+        return $this->gracePeriod;
     }
 
     // --------
@@ -31,6 +37,13 @@ class PaymentPlanConfig implements Interfaces\PaymentPlanConfig
     public function setDay($day = null)
     {
         $this->day = $day;
+
+        return $this;
+    }
+
+    public function setGracePeriod($gracePeriod = null)
+    {
+        $this->gracePeriod = $gracePeriod;
 
         return $this;
     }

--- a/lib/Structures/PaymentPlanConfigTest.php
+++ b/lib/Structures/PaymentPlanConfigTest.php
@@ -15,4 +15,9 @@ final class PaymentPlanConfigTest extends StructureTestCase
     {
         $this->full('day', 'int', false);
     }
+
+    public function test_gracePeriod()
+    {
+        $this->full('gracePeriod', 'int', false);
+    }
 }

--- a/lib/Structures/Subscription.php
+++ b/lib/Structures/Subscription.php
@@ -118,7 +118,7 @@ class Subscription implements Interfaces\Subscription
 
     public function setSplitMerchant(Interfaces\Merchant $splitMerchant = null)
     {
-        $this->spliMerchant = $splitMerchant;
+        $this->splitMerchant = $splitMerchant;
 
         return $this;
     }

--- a/lib/Transforms/Requests/Structures/PaymentPlanTransform.php
+++ b/lib/Transforms/Requests/Structures/PaymentPlanTransform.php
@@ -41,6 +41,9 @@ trait PaymentPlanTransform
             if (!is_null($transaction->object()->configuration()->day())) {
                 $request['configuration']['day'] = $transaction->object()->configuration()->day();
             }
+            if (!is_null($transaction->object()->configuration()->gracePeriod())) {
+                $request['configuration']['grace_period'] = $transaction->object()->configuration()->gracePeriod();
+            }
         }
         if (!is_null($transaction->object()->isActive())) {
             $request['is_active'] = $transaction->object()->isActive();

--- a/lib/Transforms/Responses/PaymentPlanTransform.php
+++ b/lib/Transforms/Responses/PaymentPlanTransform.php
@@ -27,6 +27,9 @@ trait PaymentPlanTransform
         if (!empty($body['configuration']['day'])) {
             $transaction->object()->configuration()->setDay($body['configuration']['day']);
         }
+        if (!empty($body['configuration']['grace_period'])) {
+            $transaction->object()->configuration()->setGracePeriod($body['configuration']['grace_period']);
+        }
         if (!empty($body['payment_priority'])) {
             $transaction->object()->setPaymentPriority($body['payment_priority']);
         }
@@ -43,6 +46,9 @@ trait PaymentPlanTransform
                 ->setMonths($planArray['configuration']['months']);
             if (isset($planArray['configuration']['day'])) {
                 $planConfig->setDay($planArray['configuration']['day']);
+            }
+            if (isset($planArray['configuration']['grace_period'])) {
+                $planConfig->setGracePeriod($planArray['configuration']['grace_period']);
             }
 
             $plan = (new Structures\PaymentPlan())
@@ -92,6 +98,9 @@ trait PaymentPlanTransform
                 );
             if (!empty($value['configuration']['day'])) {
                 $plan->configuration()->setDay($value['configuration']['day']);
+            }
+            if (!empty($value['configuration']['grace_period'])) {
+                $plan->configuration()->setGracePeriod($value['configuration']['grace_period']);
             }
             $plans[] = $plan;
         }
@@ -158,7 +167,9 @@ trait PaymentPlanTransform
 
         if (array_key_exists('split_merchant_id', $downPaymentTransactionArr)) {
             $downPayment->setSplit((new Structures\Split())
-                ->setMerchant($downPaymentTransactionArr['split_merchant_id'])
+                ->setMerchant((new Structures\Merchant())
+                    ->setID($downPaymentTransactionArr['split_merchant_id'])
+                )
                 ->setAmount($downPaymentTransactionArr['split_amount']));
         }
 
@@ -196,7 +207,7 @@ trait PaymentPlanTransform
 
         if (array_key_exists('split_merchant_id', $body)) {
             $transaction->object()->setSplitMerchant((new Structures\Merchant())
-                ->setId($body['split_merchant_id'])
+                ->setID($body['split_merchant_id'])
             );
         }
     }

--- a/tests/functional/PaymentPlans/PaymentPlanCreateSubscriptionTest.php
+++ b/tests/functional/PaymentPlans/PaymentPlanCreateSubscriptionTest.php
@@ -30,7 +30,8 @@ class PaymentPlanCreateSubscriptionTest extends FunctionalTestCase
         $subscription->downPaymentAmount = 5000;
         $subscription->day               = 10;
         $subscription->currencyCode      = 'USD';
-        $subscription->splitMerchant     = new Structures\Merchant();
+        $subscription->splitAmount       = 400;
+        $subscription->splitMerchant     = $this->splitMerchant;
 
         $subscription->paymentMethod     = $paymentMethod;
         $subscription->paymentPlan       = $paymentPlan;
@@ -48,7 +49,7 @@ class PaymentPlanCreateSubscriptionTest extends FunctionalTestCase
             [
                 'data' => [
                     'id' => 1,
-                    'split_merchant_id' => null,
+                    'split_merchant_id' => $this->splitMerchant->id(),
                     'down_payment_transaction' => [
                         'id' => 8445,
                         'created_at' => '2019-01-23 01:33:51',
@@ -60,8 +61,8 @@ class PaymentPlanCreateSubscriptionTest extends FunctionalTestCase
                         'external_id' => null,
                         'invoice_number' => null,
                         'amount' => 5000,
-                        'split_merchant_id' => null,
-                        'split_amount' => null,
+                        'split_merchant_id' => $this->splitMerchant->id(),
+                        'split_amount' => 100,
                         'fee_rate' => 3.65,
                         'fee_flat' => 30,
                         'fee_total' => 213,
@@ -99,8 +100,8 @@ class PaymentPlanCreateSubscriptionTest extends FunctionalTestCase
                             'status' => 'scheduled',
                             'currency_code' => 'USD',
                             'amount' => 1668,
-                            'split_amount' => null,
-                            'split_merchant_id' => null,
+                            'split_amount' => 100,
+                            'split_merchant_id' => $this->splitMerchant->id(),
                             'subscription' => 1,
                             'payment_method' => [
                                 'method' => 'credit_card',
@@ -135,8 +136,8 @@ class PaymentPlanCreateSubscriptionTest extends FunctionalTestCase
                             'status' => 'scheduled',
                             'currency_code' => 'USD',
                             'amount' => 1668,
-                            'split_amount' => null,
-                            'split_merchant_id' => null,
+                            'split_amount' => 100,
+                            'split_merchant_id' => $this->splitMerchant->id(),
                             'subscription' => 1,
                             'payment_method' => [
                                 'method' => 'credit_card',
@@ -171,8 +172,8 @@ class PaymentPlanCreateSubscriptionTest extends FunctionalTestCase
                             'status' => 'scheduled',
                             'currency_code' => 'USD',
                             'amount' => 1668,
-                            'split_amount' => null,
-                            'split_merchant_id' => null,
+                            'split_amount' => 100,
+                            'split_merchant_id' => $this->splitMerchant->id(),
                             'subscription' => 1,
                             'payment_method' => [
                                 'method' => 'credit_card',

--- a/tests/legacy/functional/PaymentPlans/PaymentPlanCopyWithPaymentPlanIdTest.php
+++ b/tests/legacy/functional/PaymentPlans/PaymentPlanCopyWithPaymentPlanIdTest.php
@@ -39,6 +39,7 @@ final class PaymentPlanCopyWithPaymentPlanIdTest extends TestCase
                     'configuration' => [
                         'months'          => 3,
                         'day'             => 15,
+                        'grace_period'    => 5,
                     ],
                     'payment_priority'    => 'equal',
                 ],
@@ -68,6 +69,7 @@ final class PaymentPlanCopyWithPaymentPlanIdTest extends TestCase
                     'configuration' => [
                         'months'          => $plan->configuration()->months(),
                         'day'             => $plan->configuration()->day(),
+                        'grace_period'    => $plan->configuration()->gracePeriod(),
                     ],
                     'payment_priority'    => $plan->paymentPriority(),
                 ],

--- a/tests/legacy/functional/PaymentPlans/PaymentPlanCreateSubscriptionWithPlanTest.php
+++ b/tests/legacy/functional/PaymentPlans/PaymentPlanCreateSubscriptionWithPlanTest.php
@@ -8,6 +8,7 @@ use StackPay\Payments\StackPay;
 use StackPay\Payments\Currency;
 use StackPay\Payments\Modes;
 use StackPay\Payments\Structures;
+use StackPay\Payments\PaymentPriority;
 
 use Test\Mocks\Providers\MockCurlProvider;
 
@@ -28,6 +29,7 @@ final class PaymentPlanCreateSubscriptionWithPlanTest extends TestCase
                     ->setID(1000)
                     ->setHashKey($merchantHash)
                 )
+                ->setPaymentPriority(PaymentPriority::EQUAL)
             )
             ->setPaymentMethod((new Structures\PaymentMethod())
                 ->setID(1000)
@@ -36,12 +38,15 @@ final class PaymentPlanCreateSubscriptionWithPlanTest extends TestCase
             ->setAmount(20000)
             ->setDownPaymentAmount(1500)
             ->setDay(1)
-            ->setSplitMerchant((new Structures\Merchant()));
+            ->setSplitAmount(400)
+            ->setSplitMerchant((new Structures\Merchant())
+                ->setID(1001)
+            );
         $respArray = [
             'Body' => [
                 'data' => [
                     'id' => 1,
-                    'split_merchant_id' => null,
+                    'split_merchant_id' => 1001,
                     'down_payment_transaction' => [
                         'id' => 8445,
                         'created_at' => '2019-01-23 01:33:51',
@@ -53,8 +58,8 @@ final class PaymentPlanCreateSubscriptionWithPlanTest extends TestCase
                         'external_id' => null,
                         'invoice_number' => null,
                         'amount' => 5000,
-                        'split_merchant_id' => null,
-                        'split_amount' => null,
+                        'split_merchant_id' => 1001,
+                        'split_amount' => 100,
                         'fee_rate' => 3.65,
                         'fee_flat' => 30,
                         'fee_total' => 213,
@@ -92,8 +97,8 @@ final class PaymentPlanCreateSubscriptionWithPlanTest extends TestCase
                             'status' => 'scheduled',
                             'currency_code' => 'USD',
                             'amount' => 1668,
-                            'split_amount' => null,
-                            'split_merchant_id' => null,
+                            'split_amount' => 100,
+                            'split_merchant_id' => 1001,
                             'subscription' => 1,
                             'payment_method' => [
                                 'method' => 'credit_card',
@@ -128,8 +133,8 @@ final class PaymentPlanCreateSubscriptionWithPlanTest extends TestCase
                             'status' => 'scheduled',
                             'currency_code' => 'USD',
                             'amount' => 1668,
-                            'split_amount' => null,
-                            'split_merchant_id' => null,
+                            'split_amount' => 100,
+                            'split_merchant_id' => 1001,
                             'subscription' => 1,
                             'payment_method' => [
                                 'method' => 'credit_card',
@@ -164,8 +169,8 @@ final class PaymentPlanCreateSubscriptionWithPlanTest extends TestCase
                             'status' => 'scheduled',
                             'currency_code' => 'USD',
                             'amount' => 1668,
-                            'split_amount' => null,
-                            'split_merchant_id' => null,
+                            'split_amount' => 100,
+                            'split_merchant_id' => 1001,
                             'subscription' => 1,
                             'payment_method' => [
                                 'method' => 'credit_card',
@@ -211,7 +216,7 @@ final class PaymentPlanCreateSubscriptionWithPlanTest extends TestCase
             [
                 'data' => [
                     'id' => $subscription->id(),
-                    'split_merchant_id' => null,
+                    'split_merchant_id' => 1001,
                     'down_payment_transaction'  => [
                         'id' => $subscription->downPaymentTransaction()->id(),
                         'created_at' => '2019-01-23 01:33:51',
@@ -223,8 +228,8 @@ final class PaymentPlanCreateSubscriptionWithPlanTest extends TestCase
                         'external_id' => null,
                         'invoice_number' => null,
                         'amount' => $subscription->downPaymentTransaction()->amount(),
-                        'split_merchant_id' => null,
-                        'split_amount' => null,
+                        'split_merchant_id' => 1001,
+                        'split_amount' => 100,
                         'fee_rate' => 3.65,
                         'fee_flat' => 30,
                         'fee_total' => 213,
@@ -262,8 +267,8 @@ final class PaymentPlanCreateSubscriptionWithPlanTest extends TestCase
                             'status'                => 'scheduled',
                             'currency_code'         => $subscription->scheduledTransactions()[0]->currencyCode(),
                             'amount'                => $subscription->scheduledTransactions()[0]->amount(),
-                            'split_amount'          => null,
-                            'split_merchant_id'     => null,
+                            'split_amount'          => 100,
+                            'split_merchant_id'     => 1001,
                             'subscription'          => 1,
                             'payment_method'        => [
                                 'method'            => 'credit_card',
@@ -298,8 +303,8 @@ final class PaymentPlanCreateSubscriptionWithPlanTest extends TestCase
                             'status'                => 'scheduled',
                             'currency_code'         => $subscription->scheduledTransactions()[1]->currencyCode(),
                             'amount'                => $subscription->scheduledTransactions()[1]->amount(),
-                            'split_amount'          => null,
-                            'split_merchant_id'     => null,
+                            'split_amount'          => 100,
+                            'split_merchant_id'     => 1001,
                             'subscription'          => 1,
                             'payment_method'        => [
                                 'method'            => 'credit_card',
@@ -334,8 +339,8 @@ final class PaymentPlanCreateSubscriptionWithPlanTest extends TestCase
                             'status'                => 'scheduled',
                             'currency_code'         => $subscription->scheduledTransactions()[2]->currencyCode(),
                             'amount'                => $subscription->scheduledTransactions()[2]->amount(),
-                            'split_amount'          => null,
-                            'split_merchant_id'     => null,
+                            'split_amount'          => 100,
+                            'split_merchant_id'     => 1001,
                             'subscription'          => 1,
                             'payment_method'        => [
                                 'method'            => 'credit_card',
@@ -383,6 +388,8 @@ final class PaymentPlanCreateSubscriptionWithPlanTest extends TestCase
                             'down_payment_amount' => $subscription->downPaymentAmount(),
                             'day' => $subscription->day(),
                             'currency_code' => $subscription->currencyCode(),
+                            'split_merchant_id' => $subscription->splitMerchant()->id(),
+                            'split_amount' => $subscription->splitAmount()
                         ],
                         'Header' => [
                             'Application'    => 'PaymentSystem',


### PR DESCRIPTION
…to Payment Plans

- Change composer version to be +0.0.1 to the previous release
- Add grace period to Payment Plan config
- Add tests for grace period
- Fix typo in subscription to properly set splitMerchant
- Add configuration.grace_period to both payment plan request and response transforms
- Fix bug in setting a split merchant for a down payment transaction for a subscription response
- Add split merchant and split amount to `PaymentPlanCreateSubscriptionTest`
- Add grace period to `PaymentPlanCopyWithPaymentPlanIdTest`
- Add split merchant, split amount, and split payment priority to `PaymentPlanCreateSubscriptionWithPlanTest`